### PR TITLE
Use occlusion channel in metal-roughness map and fix ambient lighting

### DIFF
--- a/simplepbr/__init__.py
+++ b/simplepbr/__init__.py
@@ -63,6 +63,7 @@ class Pipeline:
             exposure=1.0,
             enable_shadows=False,
             enable_fog=False,
+            use_occlusion_maps=False
     ):
         if render_node is None:
             render_node = base.render
@@ -83,6 +84,7 @@ class Pipeline:
         self.enable_fog = enable_fog
         self.exposure = exposure
         self.msaa_samples = msaa_samples
+        self.use_occlusion_maps = use_occlusion_maps
 
         # Create a FilterManager instance
         self.manager = FilterManager(window, camera_node)
@@ -115,6 +117,7 @@ class Pipeline:
             'use_normal_maps',
             'enable_shadows',
             'enable_fog',
+            'use_occlusion_maps',
         ]
         if name in pbr_vars and prev_value != value:
             self._recompile_pbr()
@@ -133,6 +136,8 @@ class Pipeline:
             pbr_defines['ENABLE_SHADOWS'] = ''
         if self.enable_fog:
             pbr_defines['ENABLE_FOG'] = ''
+        if self.use_occlusion_maps:
+            pbr_defines['USE_OCCLUSION_MAP'] = ''
 
         pbr_vert_str = _load_shader_str('simplepbr.vert', pbr_defines)
         pbr_frag_str = _load_shader_str('simplepbr.frag', pbr_defines)
@@ -191,6 +196,7 @@ def init(*,
          exposure=1.0,
          enable_shadows=False,
          enable_fog=False,
+         use_occlusion_maps=False
          ):
     '''Initialize the PBR render pipeline
     :param render_node: The node to attach the shader too, defaults to `base.render` if `None`
@@ -211,6 +217,9 @@ def init(*,
     :type enable_shadows: bool
     :param enable_fog: Enable exponential fog, defaults to False
     :type enable_fog: bool
+    :param use_occlusion_maps: Use occlusion maps, defaults to `False` (NOTE: Requires occlusion channel in
+    metal-roughness map)
+    :type use_occlusion_maps: bool
     '''
 
     return Pipeline(
@@ -223,4 +232,5 @@ def init(*,
         exposure=exposure,
         enable_shadows=enable_shadows,
         enable_fog=enable_fog,
+        use_occlusion_maps=use_occlusion_maps
     )

--- a/simplepbr/simplepbr.frag
+++ b/simplepbr/simplepbr.frag
@@ -125,6 +125,11 @@ void main() {
     vec3 n = v_tbn[2];
 #endif
     vec3 v = normalize(-v_position);
+#ifdef USE_OCCLUSION_MAP
+    float ambient_occlusion = metal_rough.r;
+#else
+    float ambient_occlusion = 1.0;
+#endif
 
     vec4 color = vec4(vec3(0.0), base_color.a);
 
@@ -170,7 +175,7 @@ void main() {
         color.rgb += func_params.n_dot_l * lightcol * (diffuse_contrib + spec_contrib) * shadow;
     }
 
-    color.rgb += p3d_LightModel.ambient.rgb;
+    color.rgb += diffuse_color * p3d_LightModel.ambient.rgb * ambient_occlusion;
 
 #ifdef ENABLE_FOG
     // Exponential fog


### PR DESCRIPTION
This add basic support for the occlusion map present in the R channel of the metal-roughness map (as defined by glTF)
Also the ambient lighting should be modulated by the diffuse colour otherwise it just burns the surface.