### PR TITLE
Clamp NdotL and NdotV to 0.0

### DIFF
--- a/simplepbr/shaders/simplepbr.frag
+++ b/simplepbr/shaders/simplepbr.frag
@@ -164,8 +164,8 @@ void main() {
         float shadow = shadowSpot * shadowCaster;
 
         FunctionParamters func_params;
-        func_params.n_dot_l = clamp(dot(n, l), 0.001, 1.0);
-        func_params.n_dot_v = clamp(abs(dot(n, v)), 0.001, 1.0);
+        func_params.n_dot_l = clamp(dot(n, l), 0.0, 1.0);
+        func_params.n_dot_v = clamp(abs(dot(n, v)), 0.0, 1.0);
         func_params.n_dot_h = clamp(dot(n, h), 0.0, 1.0);
         func_params.l_dot_h = clamp(dot(l, h), 0.0, 1.0);
         func_params.v_dot_h = clamp(dot(v, h), 0.0, 1.0);


### PR DESCRIPTION
Followup to https://discourse.panda3d.org/t/directional-light-sun-penetrates-model-from-the-backside/26191/17

In the fragment shader the values of n_dot_l and n_dot_v are clamped between 0.001 and 1.0 The lower bound is not 0 and so introduces artefact on smooth surfaces. Even if the value is quite low, the strength of the specular reflection is big enough to be visible.

Here is a short code to reproduce the problem :

```
from direct.showbase.ShowBase import ShowBase
from panda3d.core import CardMaker, DirectionalLight, Material
from panda3d.core import LVector3

import simplepbr

from math import cos, sin, pi

class Demo():
    def __init__(self):
        self.light_angle = 0.0
        self.light = None
        self.lightnp = None
        self.camera_angle = 0.0
        self.camera_distance = 5.0

    def move_light(self, incr):
        self.light_angle += incr
        print("Light angle", self.light_angle)
        angle_rad = self.light_angle * pi / 180
        self.light.set_direction(LVector3(0.0, cos(angle_rad), sin(angle_rad)))

    def move_camera(self, incr):
        self.camera_angle += incr
        print("Camera angle", self.camera_angle)
        angle_rad = self.camera_angle * pi / 180
        base.camera.set_pos(LVector3(0.0,
                                     -self.camera_distance * cos(angle_rad),
                                     self.camera_distance * sin(angle_rad)))
        base.camera.look_at(self.lightnp)
        print(base.camera.get_pos())

    def run(self):
        base = ShowBase()
        base.disable_mouse()
        
        self.pipeline = simplepbr.init()

        cm = CardMaker('card')
        cm.set_frame(-.5, .5, -.5, .5)
        np = render.attach_new_node(cm.generate())
        np.set_scale(2)
        material = Material()
        material.set_base_color((1, 0, 0, 1))
        material.set_roughness(0.1)
        np.set_material(material)
        print(material)
        
        self.light = DirectionalLight('light')
        self.lightnp = render.attach_new_node(self.light)
        render.set_light(self.lightnp)
        self.move_light(-95)
        self.move_camera(-80)
        base.accept('l', self.move_light, [1])
        base.accept('shift-l', self.move_light, [-1])
        base.accept('c', self.move_camera, [10])
        base.accept('shift-c', self.move_camera, [-10])
        base.run()

demo = Demo()
demo.run()
```

No other PBR shaders I have looked at (Khronos glTF Sample Viewer, Babylon.JS, Three.JS, ...)  have a lower bound other than 0.0
