### PR TITLE
use absolute path for shader - prevent collision with user shaders dir

### DIFF
--- a/simplepbr/__init__.py
+++ b/simplepbr/__init__.py
@@ -1,5 +1,5 @@
 import os
-
+from pathlib import Path
 import panda3d.core as p3d
 
 from direct.filter.FilterManager import FilterManager
@@ -40,12 +40,9 @@ def _add_shader_defines(shaderstr, defines):
 
 
 def _load_shader_str(shaderpath, defines=None):
-    shader_dir = os.path.join(os.curdir, "shaders")
+    shader_dir = Path(__file__).parent.absolute() / "shaders"
 
-    if not os.path.exists(shader_dir):
-        shader_dir = os.path.join(os.path.dirname(__file__), 'shaders')
-
-    with open(os.path.join(shader_dir, shaderpath)) as shaderfile:
+    with open(shader_dir / shaderpath) as shaderfile:
         shaderstr = shaderfile.read()
 
     if defines is None:


### PR DESCRIPTION
Was getting the following error with the package. Resolved by making paths absolute. 
Consider this pull as a solution.

```python
Traceback (most recent call last):
  File "/home/ranjian0/Development/Games/RoadRage/src/main.py", line 97, in <module>
    app = GLTFLoading()
  File "/home/ranjian0/Development/Games/RoadRage/src/main.py", line 25, in __init__
    self.pipeline = simplepbr.init()
  File "/home/ranjian0/Development/Games/RoadRage/.venv/lib/python3.9/site-packages/simplepbr/__init__.py", line 351, in init
    return Pipeline(**kwargs)
  File "/home/ranjian0/Development/Games/RoadRage/.venv/lib/python3.9/site-packages/simplepbr/__init__.py", line 129, in __init__
    self._recompile_pbr()
  File "/home/ranjian0/Development/Games/RoadRage/.venv/lib/python3.9/site-packages/simplepbr/__init__.py", line 215, in _recompile_pbr
    pbr_vert_str = _load_shader_str('simplepbr.vert', pbr_defines)
  File "/home/ranjian0/Development/Games/RoadRage/.venv/lib/python3.9/site-packages/simplepbr/__init__.py", line 49, in _load_shader_str
    with open(os.path.join(shader_dir, shaderpath)) as shaderfile:
FileNotFoundError: [Errno 2] No such file or directory: './shaders/simplepbr.vert'
```