### PR TITLE
Fix error with empty camera on DisplayRegion

### DIFF
--- a/simplepbr/__init__.py
+++ b/simplepbr/__init__.py
@@ -373,7 +373,7 @@ class Pipeline:
         return [
             i.node()
             for i in cameras
-            if hasattr(i.node(), 'is_shadow_caster') and i.node().is_shadow_caster()
+            if not i.is_empty() and hasattr(i.node(), 'is_shadow_caster') and i.node().is_shadow_caster()
         ]
 
     def _create_shadow_shader_attrib(self):


### PR DESCRIPTION
This should fix an assertion that occurs when a DisplayRegion exists anywhere in the program that doesn't have a camera.

See:
https://discourse.panda3d.org/t/how-to-use-multiple-cameras-with-simplepbr/29187