### PR TITLE
Explicitly disable sRGB in HDR framebuffer

### DIFF
--- a/simplepbr/__init__.py
+++ b/simplepbr/__init__.py
@@ -308,6 +308,7 @@ class Pipeline:
 
         fbprops = p3d.FrameBufferProperties()
         fbprops.float_color = True
+        fbprops.srgb_color = False
         fbprops.set_rgba_bits(16, 16, 16, 16)
         fbprops.set_depth_bits(24)
         fbprops.set_multisamples(self.msaa_samples)


### PR DESCRIPTION
This seems to be necessary to avoid a failure to create the framebuffer on macOS when `framebuffer-srgb` is set in Config.prc.  Not sure why, probably worth investigating as an issue in Panda, but this is a good thing anyway - we never want this to be sRGB if it's floating point.