### PR TITLE
Give update task sort value of 49

### DIFF
--- a/simplepbr/__init__.py
+++ b/simplepbr/__init__.py
@@ -211,7 +211,7 @@ class Pipeline:
         self._setup_tonemapping()
 
         # Do updates based on scene changes
-        self.taskmgr.add(self._update, 'simplepbr update')
+        self.taskmgr.add(self._update, 'simplepbr update', sort=49)
 
         self._shader_ready = True
 


### PR DESCRIPTION
This is right before the igLoop sort of 50.  Makes sure that the IBL update doesn't lag behind by one frame.

Fixes #57