### PR TITLE
Fix `tonemap.frag` ignoring alpha value

### DIFF
--- a/simplepbr/shaders/tonemap.frag
+++ b/simplepbr/shaders/tonemap.frag
@@ -19,7 +19,8 @@ out vec4 o_color;
 #endif
 
 void main() {
-    vec3 color = texture2D(tex, v_texcoord).rgb;
+    vec4 texColor = texture2D(tex, v_texcoord);
+    vec3 color = texColor.rgb;
 
     color *= exposure;
     color = max(vec3(0.0), color - vec3(0.004));
@@ -32,8 +33,8 @@ void main() {
     color = mix(color, lut_color, sdr_lut_factor);
 #endif
 #ifdef USE_330
-    o_color = vec4(color, 1.0);
+    oo_color = vec4(color, texColor.a);
 #else
-    gl_FragColor = vec4(color, 1.0);
+    gl_FragColor = vec4(color, texColor.a);
 #endif
 }

--- a/simplepbr/shaders/tonemap.frag
+++ b/simplepbr/shaders/tonemap.frag
@@ -33,7 +33,7 @@ void main() {
     color = mix(color, lut_color, sdr_lut_factor);
 #endif
 #ifdef USE_330
-    oo_color = vec4(color, texColor.a);
+    o_color = vec4(color, texColor.a);
 #else
     gl_FragColor = vec4(color, texColor.a);
 #endif


### PR DESCRIPTION
Closes https://github.com/Moguri/panda3d-simplepbr/issues/60

The tonemap shader was always setting the alpha value to `1.0` thus, not respecting the clear color alpha channel. This change handles that issue.